### PR TITLE
add support for application/json as Unicode text

### DIFF
--- a/src/zope/publisher/http.py
+++ b/src/zope/publisher/http.py
@@ -60,7 +60,8 @@ ENCODING = 'UTF-8'
 
 # not just text/* but RFC 3023 and */*+xml
 import re
-unicode_mimetypes_re = re.compile(r"^text\/.*$|^.*\/xml.*$|^.*\+xml$")
+unicode_mimetypes_re = re.compile(
+    r"^text\/.*$|^.*\/xml.*$|^.*\+xml$|^application/json$")
 
 eventlog = logging.getLogger('eventlog')
 
@@ -819,8 +820,8 @@ class HTTPResponse(BaseResponse):
             ct = content_type
             if not unicode_mimetypes_re.match(ct):
                 raise ValueError(
-                    'Unicode results must have a text, RFC 3023, or '
-                    '+xml content type.')
+                    'Unicode results must have a text, RFC 3023, RFC 4627,'
+                    ' or +xml content type.')
 
             major, minor, params = zope.contenttype.parse.parse(ct)
 
@@ -836,9 +837,14 @@ class HTTPResponse(BaseResponse):
                 encoding = 'utf-8'
                 body = body.encode(encoding)
 
-            params['charset'] = encoding
-            content_type = "%s/%s;" % (major, minor)
-            content_type += ";".join(k + "=" + v for k, v in params.items())
+            if (major, minor) != ('application', 'json'):
+                # The RFC says this is UTF-8, and the type has no params.
+                params['charset'] = encoding
+            content_type = "%s/%s" % (major, minor)
+            if params:
+                content_type += ";"
+                content_type += ";".join(k + "=" + v
+                                         for k, v in params.items())
 
         if content_type:
             headers = [('content-type', content_type),

--- a/src/zope/publisher/tests/test_http.py
+++ b/src/zope/publisher/tests/test_http.py
@@ -836,6 +836,11 @@ class TestHTTPResponse(unittest.TestCase):
         eq("image/gif", headers["Content-Type"])
         eq(b"test", body)
 
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
+            {"content-type": "application/json"})
+        eq("application/json", headers["Content-Type"])
+        eq(b"test", body)
+
     def _getCookieFromResponse(self, cookies):
         # Shove the cookies through request, parse the Set-Cookie header
         # and spit out a list of headers for examination


### PR DESCRIPTION
This patch allows application/json responses represented as Unicode text to be encoded by the publisher.
