### PR TITLE
Compatibility with PythonScripts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,10 @@ Changes
 4.3.1 (unreleased)
 ------------------
 
-- Use ``six`` to access the function object and function code in ``zope.publisher.publisher.unwrapMethod``.
-  This restores compatibility with Products.PythonScripts, where parameters were not extracted.
-  [maurits, thet]
+- Accept both new and old locations for ``__code__`` in
+  ``zope.publisher.publisher.unwrapMethod``. This restores compatibility with
+  Products.PythonScripts, where parameters were not extracted.
+  [maurits, thet, MatthewWilkes]
 
 - Fix file uploads on python 3.4 and up. cgi.FieldStorage explicitly
   closes files when it is garbage collected. For details, see:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 4.3.1 (unreleased)
 ------------------
 
-- TBD
+- Use ``six`` to access the function object and function code in ``zope.publisher.publisher.unwrapMethod``.
+  This restores compatibility with Products.PythonScripts, where parameters were not extracted.
+  [maurits, thet]
 
 
 4.3.0 (2016-07-04)

--- a/src/zope/publisher/publish.py
+++ b/src/zope/publisher/publish.py
@@ -25,6 +25,7 @@ from zope.proxy import removeAllProxies
 
 _marker = object()  # Create a new marker object.
 
+
 def unwrapMethod(obj):
     """obj -> (unwrapped, wrapperCount)
 
@@ -41,14 +42,14 @@ def unwrapMethod(obj):
         if bases is not None:
             raise TypeError("mapply() can not call class constructors")
 
-        im_func = getattr(unwrapped, '__func__', None)
+        im_func = getattr(unwrapped, six._meth_func, None)
         if im_func is not None:
             unwrapped = im_func
             wrapperCount += 1
-        elif getattr(unwrapped, '__code__', None) is not None:
+        elif getattr(unwrapped, six._func_code, None) is not None:
             break
         else:
-            unwrapped = getattr(unwrapped, '__call__' , None)
+            unwrapped = getattr(unwrapped, '__call__', None)
             if unwrapped is None:
                 raise TypeError("mapply() can not call %s" % repr(obj))
     else:

--- a/src/zope/publisher/publish.py
+++ b/src/zope/publisher/publish.py
@@ -42,11 +42,16 @@ def unwrapMethod(obj):
         if bases is not None:
             raise TypeError("mapply() can not call class constructors")
 
-        im_func = getattr(unwrapped, six._meth_func, None)
+        im_func = getattr(unwrapped, '__func__', None)
+        if im_func is None:
+            # Backwards compatibility with objects aimed at Python 2
+            im_func = getattr(unwrapped, 'im_func', None)
         if im_func is not None:
             unwrapped = im_func
             wrapperCount += 1
-        elif getattr(unwrapped, six._func_code, None) is not None:
+        elif getattr(unwrapped, '__code__', None) is not None:
+            break
+        elif getattr(unwrapped, 'func_code', None) is not None:
             break
         else:
             unwrapped = getattr(unwrapped, '__call__', None)

--- a/src/zope/publisher/publish.py
+++ b/src/zope/publisher/publish.py
@@ -72,8 +72,12 @@ def mapply(obj, positional=(), request={}):
 
     unwrapped, wrapperCount = unwrapMethod(unwrapped)
 
-    code = unwrapped.__code__
-    defaults = unwrapped.__defaults__
+    code = getattr(unwrapped, '__code__', None)
+    if code is None:
+        code = unwrapped.func_code
+    defaults = getattr(unwrapped, '__defaults__', None)
+    if defaults is None:
+        defaults = getattr(unwrapped, 'func_defaults', None)
     names = code.co_varnames[wrapperCount:code.co_argcount]
 
     nargs = len(names)


### PR DESCRIPTION
Use `six` to access the function object and function code in `zope.publisher.publisher.unwrapMethod`.
This restores compatibility with Products.PythonScripts, where parameters were not extracted.
