### PR TITLE
Fix POST with large values on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Changes
   We now keep a reference to the FieldStorage till we are finished
   processing the request.
 
+- Fix POST with large values on Python 3. Related to cgi.FieldStorage
+  doing the decoding in Python 3.
+
 4.3.0 (2016-07-04)
 ------------------
 

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -613,7 +613,11 @@ class BrowserRequest(HTTPRequest):
 class ZopeFieldStorage(FieldStorage):
 
     def make_file(self, binary=None):
-        return tempfile.NamedTemporaryFile('w+b')
+        if PYTHON2 or self._binary_file:
+            return tempfile.NamedTemporaryFile("w+b")
+        else:
+            return tempfile.NamedTemporaryFile("w+",
+                    encoding=self.encoding, newline='\n')
 
 
 class FileUpload(object):

--- a/src/zope/publisher/tests/test_browserrequest.py
+++ b/src/zope/publisher/tests/test_browserrequest.py
@@ -48,6 +48,13 @@ Here comes some text! """, (b'test'*1000), b"""
 -----------------------------1--
 """])
 
+LARGE_POSTED_VALUE = b''.join([b"""-----------------------------1
+Content-Disposition: form-data; name="upload"
+
+Here comes some text! """, (b'test'*1000), b"""
+-----------------------------1--
+"""])
+
 IE_FILE_BODY = b"""-----------------------------1
 Content-Disposition: form-data; name="upload"; filename="C:\\Windows\\notepad.exe"
 Content-Type: text/plain
@@ -219,6 +226,15 @@ class BrowserTests(HTTPTests):
 
         # Test that we can actually read the file data
         self.assertEqual(request.form['upload'].read(), b'Some data')
+
+    def testLargePostValue(self):
+        extra = {'REQUEST_METHOD':'POST',
+                 'PATH_INFO': _u("/"),
+                 'CONTENT_TYPE': 'multipart/form-data;\
+                 boundary=---------------------------1'}
+
+        request  = self._createRequest(extra, body=LARGE_POSTED_VALUE)
+        request.processInputs()
 
     def testDefault2(self):
         extra = {'PATH_INFO': '/folder/item2/view'}


### PR DESCRIPTION
Results in a traceback looking like this:

 ```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/zope/publisher/publish.py", line 127, in publish
    request.processInputs()
  File "/usr/lib/python3/dist-packages/zope/publisher/browser.py", line 318, in processInputs
    keep_blank_values=1, **args)
  File "/usr/lib/python3.5/cgi.py", line 559, in __init__
    self.read_multi(environ, keep_blank_values, strict_parsing)
  File "/usr/lib/python3.5/cgi.py", line 730, in read_multi
    self.encoding, self.errors)
  File "/usr/lib/python3.5/cgi.py", line 561, in __init__
    self.read_single()
  File "/usr/lib/python3.5/cgi.py", line 743, in read_single
    self.read_lines()
  File "/usr/lib/python3.5/cgi.py", line 772, in read_lines
    self.read_lines_to_outerboundary()
  File "/usr/lib/python3.5/cgi.py", line 848, in read_lines_to_outerboundary
    self.__write(odelim + line)
  File "/usr/lib/python3.5/cgi.py", line 782, in __write
    self.file.write(data)
  File "/usr/lib/python3.5/tempfile.py", line 622, in func_wrapper
    return func(*args, **kwargs)
TypeError: a bytes-like object is required, not 'str'
```