### PR TITLE
Encode XMLRPC response bodies to bytes if needed. 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source = zope.publisher
+omit =
+    */flycheck_*py
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 *.pyc
 .dir-locals.el
 docs/_build
+.coverage
+htmlcov/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@
 
 - Drop support for Python 3.3.
 
+- Fix ``XMLRPCResponse`` having a str body (instead of a bytes body)
+  which could lead to ``TypeError`` on Python 3. See `issue 26
+  <https://github.com/zopefoundation/zope.publisher/issues/26>`_.
+
 
 4.3.2 (2017-05-23)
 ==================

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include *.rst
 include *.txt
 include tox.ini
+include .travis.yml
+include .coveragerc
 include bootstrap.py
 include buildout.cfg
 

--- a/src/zope/publisher/xmlrpc.py
+++ b/src/zope/publisher/xmlrpc.py
@@ -121,6 +121,12 @@ class XMLRPCResponse(HTTPResponse):
                 self.handleException(sys.exc_info())
                 return
 
+        # HTTP response payloads are byte strings, and methods like
+        # consumeBody rely on that, but xmlrpc.client.dumps produces
+        # native strings, which is incorrect on Python 3.
+        if not isinstance(body, bytes):
+            body = body.encode('utf-8')
+
         headers = [('content-type', 'text/xml;charset=utf-8'),
                    ('content-length', str(len(body)))]
         self._headers.update(dict((k, [v]) for (k, v) in headers))
@@ -172,7 +178,7 @@ class XMLRPCResponse(HTTPResponse):
 
 @implementer(IXMLRPCView)
 class XMLRPCView(object):
-    """A base XML-RPC view that can be used as mix-in for XML-RPC views.""" 
+    """A base XML-RPC view that can be used as mix-in for XML-RPC views."""
 
     def __init__(self, context, request):
         self.context = context

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,pypy,pypy3,docs
+    py27,py34,py35,py36,pypy,pypy3,docs,coverage
 
 [testenv]
 commands =
@@ -18,20 +18,15 @@ setenv =
     LC_CTYPE=en_US.UTF-8
 
 [testenv:coverage]
+usedevelop = true
 basepython =
-    python2.7
+    python3.6
 commands =
-#   The installed version messes up nose's test discovery / coverage reporting
-#   So, we uninstall that from the environment, and then install the editable
-#   version, before running nosetests.
-    pip uninstall -y zope.publisher
-    pip install -e .[test]
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=92
 deps =
-    nose
+    {[testenv]deps}
     coverage
-    nosexcover
-    .[test]
 
 
 [testenv:docs]


### PR DESCRIPTION
Fixes #26. 

Also use a modern tox coverage environment and remove outdated PyPy 2.5.0 workarounds in test_xmlrpc.py.