### PR TITLE
Refactoring: use u"" literals instead of _u("...")

### DIFF
--- a/src/zope/publisher/http.py
+++ b/src/zope/publisher/http.py
@@ -877,17 +877,16 @@ class HTTPResponse(BaseResponse):
 
     def internalError(self):
         'See IPublisherResponse'
-        self.setStatus(500, _u("The engines can't take any more, Jim!"))
+        self.setStatus(500, u"The engines can't take any more, Jim!")
 
     def _html(self, title, content):
         t = escape(title)
         return (
-            _u("<html><head><title>%s</title></head>\n"
-               "<body><h2>%s</h2>\n"
-               "%s\n"
-               "</body></html>\n") %
-            (t, t, content)
-            )
+            u"<html><head><title>%s</title></head>\n"
+            u"<body><h2>%s</h2>\n"
+            u"%s\n"
+            u"</body></html>\n"
+        ) % (t, t, content)
 
     def retry(self):
         """

--- a/src/zope/publisher/interfaces/http.py
+++ b/src/zope/publisher/interfaces/http.py
@@ -27,7 +27,6 @@ from zope.publisher.interfaces import IRequest
 from zope.publisher.interfaces import IResponse
 from zope.publisher.interfaces import IView
 
-from .._compat import _u
 
 class IVirtualHostRequest(Interface):
     """The support for virtual hosts in Zope is very important.
@@ -481,8 +480,8 @@ class IHTTPVirtualHostChangedEvent(Interface):
     The request referred to in this event implements at least the
     IHTTPAppliationRequest interface.
     """
-    request = Attribute(_u("The application request whose virtual host info has "
-                           "been altered"))
+    request = Attribute("The application request whose virtual host info has "
+                        "been altered")
 
 class IHTTPException(Interface):
     """Marker interface for http exceptions views

--- a/src/zope/publisher/tests/test_browserrequest.py
+++ b/src/zope/publisher/tests/test_browserrequest.py
@@ -29,7 +29,7 @@ from zope.publisher.interfaces.browser import IBrowserRequest
 from zope.publisher.interfaces.browser import IBrowserPublication
 from zope.publisher.base import DefaultPublication
 
-from zope.publisher._compat import PYTHON2, _u
+from zope.publisher._compat import PYTHON2
 from zope.publisher.tests.test_http import HTTPTests
 from zope.publisher.tests.publication import TestPublication
 
@@ -112,12 +112,12 @@ class BrowserTests(HTTPTests):
         class Item(object):
             """Required docstring for the publisher."""
             def __call__(self, a, b):
-                return _u("%s, %s") % (repr(a).lstrip('u'), repr(b).lstrip('u'))
+                return u"%s, %s" % (repr(a).lstrip('u'), repr(b).lstrip('u'))
 
         class Item3(object):
             """Required docstring for the publisher."""
             def __call__(self, *args):
-                return _u("...")
+                return u"..."
 
         class View(object):
             """Required docstring for the publisher."""
@@ -126,7 +126,7 @@ class BrowserTests(HTTPTests):
 
             def index(self, a, b):
                 """Required docstring for the publisher."""
-                return _u("%s, %s") % (repr(a).lstrip('u'), repr(b).lstrip('u'))
+                return u"%s, %s" % (repr(a).lstrip('u'), repr(b).lstrip('u'))
 
         class Item2(object):
             """Required docstring for the publisher."""
@@ -193,8 +193,8 @@ class BrowserTests(HTTPTests):
         """Produce a Fieldstorage with a name wich is None, this
         should be catched"""
 
-        extra = {'REQUEST_METHOD':'POST',
-                 'PATH_INFO': _u("/"),
+        extra = {'REQUEST_METHOD': 'POST',
+                 'PATH_INFO': u"/",
                  'CONTENT_TYPE': 'multipart/form-data;\
                  boundary=---------------------------1'}
 
@@ -211,8 +211,8 @@ class BrowserTests(HTTPTests):
         """Produce a Fieldstorage with a file handle that exposes
         its filename."""
 
-        extra = {'REQUEST_METHOD':'POST',
-                 'PATH_INFO': _u("/"),
+        extra = {'REQUEST_METHOD': 'POST',
+                 'PATH_INFO': u"/",
                  'CONTENT_TYPE': 'multipart/form-data;\
                  boundary=---------------------------1'}
 
@@ -229,7 +229,7 @@ class BrowserTests(HTTPTests):
 
     def testLargePostValue(self):
         extra = {'REQUEST_METHOD':'POST',
-                 'PATH_INFO': _u("/"),
+                 'PATH_INFO': u"/",
                  'CONTENT_TYPE': 'multipart/form-data;\
                  boundary=---------------------------1'}
 
@@ -280,7 +280,7 @@ class BrowserTests(HTTPTests):
         request = self._createRequest()
         publish(request)
         self.assertEqual(request.form,
-                         {_u("a"):_u("5"), _u("b"):6})
+                         {u"a": u"5", u"b": 6})
 
     def testFormNoEncodingUsesUTF8(self):
         encoded = 'K\xc3\xb6hlerstra\xc3\x9fe'
@@ -293,8 +293,8 @@ class BrowserTests(HTTPTests):
         # many mainstream browsers do not send HTTP_ACCEPT_CHARSET
         del request._environ['HTTP_ACCEPT_CHARSET']
         publish(request)
-        self.assertTrue(isinstance(request.form[_u("street")], unicode))
-        self.assertEqual(_u("K\xf6hlerstra\xdfe"), request.form['street'])
+        self.assertTrue(isinstance(request.form[u"street"], unicode))
+        self.assertEqual(u"K\xf6hlerstra\xdfe", request.form['street'])
 
     def testFormAcceptsStarButNotUTF8(self):
         extra = {
@@ -306,204 +306,204 @@ class BrowserTests(HTTPTests):
         publish(request)
 
     def testFormListTypes(self):
-        extra = {'QUERY_STRING':'a:list=5&a:list=6&b=1'}
+        extra = {'QUERY_STRING': 'a:list=5&a:list=6&b=1'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"):[_u("5"),_u("6")], _u("b"):_u("1")})
+        self.assertEqual(request.form, {u"a": [u"5",u"6"], u"b": u"1"})
 
     def testQueryStringIgnoredForPOST(self):
         request = self._createRequest(
             {"REQUEST_METHOD": "POST",
              'PATH_INFO': '/folder/item3'}, body=b'c=5&d:int=6')
         publish(request)
-        self.assertEqual(request.form, {_u("c"): _u("5"), _u("d"): 6})
+        self.assertEqual(request.form, {u"c": u"5", u"d": 6})
         self.assertEqual(request.get('QUERY_STRING'), 'a=5&b:int=6')
 
     def testFormTupleTypes(self):
-        extra = {'QUERY_STRING':'a:tuple=5&a:tuple=6&b=1'}
+        extra = {'QUERY_STRING': 'a:tuple=5&a:tuple=6&b=1'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"):(_u("5"),_u("6")), _u("b"):_u("1")})
+        self.assertEqual(request.form, {u"a": (u"5", u"6"), u"b": u"1"})
 
     def testFormTupleRecordTypes(self):
-        extra = {'QUERY_STRING':'a.x:tuple:record=5&a.x:tuple:record=6&b=1'}
+        extra = {'QUERY_STRING': 'a.x:tuple:record=5&a.x:tuple:record=6&b=1'}
         request = self._createRequest(extra)
         publish(request)
         keys = sorted(request.form.keys())
-        self.assertEqual(keys, [_u("a"),_u("b")])
-        self.assertEqual(request.form[_u("b")], _u("1"))
-        self.assertEqual(list(request.form[_u("a")].keys()), [_u("x")])
-        self.assertEqual(request.form[_u("a")][_u("x")], (_u("5"),_u("6")))
-        self.assertEqual(request.form[_u("a")].x, (_u("5"),_u("6")))
-        self.assertEqual(str(request.form[_u("a")]).replace("u'", "'"),
+        self.assertEqual(keys, [u"a", u"b"])
+        self.assertEqual(request.form[u"b"], u"1")
+        self.assertEqual(list(request.form[u"a"].keys()), [u"x"])
+        self.assertEqual(request.form[u"a"][u"x"], (u"5", u"6"))
+        self.assertEqual(request.form[u"a"].x, (u"5", u"6"))
+        self.assertEqual(str(request.form[u"a"]).replace("u'", "'"),
                          "{x: ('5', '6')}")
-        self.assertEqual(repr(request.form[_u("a")]).replace("u'", "'"),
+        self.assertEqual(repr(request.form[u"a"]).replace("u'", "'"),
                          "{x: ('5', '6')}")
 
     def testFormRecordsTypes(self):
-        extra = {'QUERY_STRING':'a.x:records=5&a.x:records=6&b=1'}
+        extra = {'QUERY_STRING': 'a.x:records=5&a.x:records=6&b=1'}
         request = self._createRequest(extra)
         publish(request)
         keys = sorted(request.form.keys())
-        self.assertEqual(keys, [_u("a"),_u("b")])
-        self.assertEqual(request.form[_u("b")], _u("1"))
-        self.assertEqual(len(request.form[_u("a")]), 2)
-        self.assertEqual(request.form[_u("a")][0][_u("x")], _u("5"))
-        self.assertEqual(request.form[_u("a")][0].x, _u("5"))
-        self.assertEqual(request.form[_u("a")][1][_u("x")], _u("6"))
-        self.assertEqual(request.form[_u("a")][1].x, _u("6"))
-        self.assertEqual(str(request.form[_u("a")]).replace("u'", "'"),
+        self.assertEqual(keys, [u"a", u"b"])
+        self.assertEqual(request.form[u"b"], u"1")
+        self.assertEqual(len(request.form[u"a"]), 2)
+        self.assertEqual(request.form[u"a"][0][u"x"], u"5")
+        self.assertEqual(request.form[u"a"][0].x, u"5")
+        self.assertEqual(request.form[u"a"][1][u"x"], u"6")
+        self.assertEqual(request.form[u"a"][1].x, u"6")
+        self.assertEqual(str(request.form[u"a"]).replace("u'", "'"),
                          "[{x: '5'}, {x: '6'}]")
-        self.assertEqual(repr(request.form[_u("a")]).replace("u'", "'"),
+        self.assertEqual(repr(request.form[u"a"]).replace("u'", "'"),
                          "[{x: '5'}, {x: '6'}]")
 
     def testFormMultipleRecordsTypes(self):
-        extra = {'QUERY_STRING':'a.x:records:int=5&a.y:records:int=51'
+        extra = {'QUERY_STRING': 'a.x:records:int=5&a.y:records:int=51'
             '&a.x:records:int=6&a.y:records:int=61&b=1'}
         request = self._createRequest(extra)
         publish(request)
         keys = sorted(request.form.keys())
-        self.assertEqual(keys, [_u("a"),_u("b")])
-        self.assertEqual(request.form[_u("b")], _u("1"))
-        self.assertEqual(len(request.form[_u("a")]), 2)
-        self.assertEqual(request.form[_u("a")][0][_u("x")], 5)
-        self.assertEqual(request.form[_u("a")][0].x, 5)
-        self.assertEqual(request.form[_u("a")][0][_u("y")], 51)
-        self.assertEqual(request.form[_u("a")][0].y, 51)
-        self.assertEqual(request.form[_u("a")][1][_u("x")], 6)
-        self.assertEqual(request.form[_u("a")][1].x, 6)
-        self.assertEqual(request.form[_u("a")][1][_u("y")], 61)
-        self.assertEqual(request.form[_u("a")][1].y, 61)
-        self.assertEqual(str(request.form[_u("a")]),
+        self.assertEqual(keys, [u"a", u"b"])
+        self.assertEqual(request.form[u"b"], u"1")
+        self.assertEqual(len(request.form[u"a"]), 2)
+        self.assertEqual(request.form[u"a"][0][u"x"], 5)
+        self.assertEqual(request.form[u"a"][0].x, 5)
+        self.assertEqual(request.form[u"a"][0][u"y"], 51)
+        self.assertEqual(request.form[u"a"][0].y, 51)
+        self.assertEqual(request.form[u"a"][1][u"x"], 6)
+        self.assertEqual(request.form[u"a"][1].x, 6)
+        self.assertEqual(request.form[u"a"][1][u"y"], 61)
+        self.assertEqual(request.form[u"a"][1].y, 61)
+        self.assertEqual(str(request.form[u"a"]),
             "[{x: 5, y: 51}, {x: 6, y: 61}]")
-        self.assertEqual(repr(request.form[_u("a")]),
+        self.assertEqual(repr(request.form[u"a"]),
             "[{x: 5, y: 51}, {x: 6, y: 61}]")
 
     def testFormListRecordTypes(self):
-        extra = {'QUERY_STRING':'a.x:list:record=5&a.x:list:record=6&b=1'}
+        extra = {'QUERY_STRING': 'a.x:list:record=5&a.x:list:record=6&b=1'}
         request = self._createRequest(extra)
         publish(request)
         keys = sorted(request.form.keys())
-        self.assertEqual(keys, [_u("a"),_u("b")])
-        self.assertEqual(request.form[_u("b")], _u("1"))
-        self.assertEqual(list(request.form[_u("a")].keys()), [_u("x")])
-        self.assertEqual(request.form[_u("a")][_u("x")], [_u("5"),_u("6")])
-        self.assertEqual(request.form[_u("a")].x, [_u("5"),_u("6")])
-        self.assertEqual(str(request.form[_u("a")]).replace("u'", "'"),
+        self.assertEqual(keys, [u"a", u"b"])
+        self.assertEqual(request.form[u"b"], u"1")
+        self.assertEqual(list(request.form[u"a"].keys()), [u"x"])
+        self.assertEqual(request.form[u"a"][u"x"], [u"5", u"6"])
+        self.assertEqual(request.form[u"a"].x, [u"5", u"6"])
+        self.assertEqual(str(request.form[u"a"]).replace("u'", "'"),
                          "{x: ['5', '6']}")
-        self.assertEqual(repr(request.form[_u("a")]).replace("u'", "'"),
+        self.assertEqual(repr(request.form[u"a"]).replace("u'", "'"),
                          "{x: ['5', '6']}")
 
     def testFormListTypes2(self):
-        extra = {'QUERY_STRING':'a=5&a=6&b=1'}
+        extra = {'QUERY_STRING': 'a=5&a=6&b=1'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"):[_u("5"),_u("6")], _u("b"):_u("1")})
+        self.assertEqual(request.form, {u"a": [u"5", u"6"], u"b": u"1"})
 
     def testFormIntTypes(self):
-        extra = {'QUERY_STRING':'a:int=5&b:int=-5&c:int=0&d:int=-0'}
+        extra = {'QUERY_STRING': 'a:int=5&b:int=-5&c:int=0&d:int=-0'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): 5, _u("b"): -5, _u("c"): 0, _u("d"): 0})
+        self.assertEqual(request.form, {u"a": 5, u"b": -5, u"c": 0, u"d": 0})
 
-        extra = {'QUERY_STRING':'a:int='}
+        extra = {'QUERY_STRING': 'a:int='}
         request = self._createRequest(extra)
         self.assertRaises(ValueError, publish, request)
 
-        extra = {'QUERY_STRING':'a:int=abc'}
+        extra = {'QUERY_STRING': 'a:int=abc'}
         request = self._createRequest(extra)
         self.assertRaises(ValueError, publish, request)
 
     def testFormFloatTypes(self):
-        extra = {'QUERY_STRING':'a:float=5&b:float=-5.01&c:float=0'}
+        extra = {'QUERY_STRING': 'a:float=5&b:float=-5.01&c:float=0'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): 5.0, _u("b"): -5.01, _u("c"): 0.0})
+        self.assertEqual(request.form, {u"a": 5.0, u"b": -5.01, u"c": 0.0})
 
-        extra = {'QUERY_STRING':'a:float='}
+        extra = {'QUERY_STRING': 'a:float='}
         request = self._createRequest(extra)
         self.assertRaises(ValueError, publish, request)
 
-        extra = {'QUERY_STRING':'a:float=abc'}
+        extra = {'QUERY_STRING': 'a:float=abc'}
         request = self._createRequest(extra)
         self.assertRaises(ValueError, publish, request)
 
     def testFormLongTypes(self):
-        extra = {'QUERY_STRING':'a:long=99999999999999&b:long=0L'}
+        extra = {'QUERY_STRING': 'a:long=99999999999999&b:long=0L'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): 99999999999999, _u("b"): 0})
+        self.assertEqual(request.form, {u"a": 99999999999999, u"b": 0})
 
-        extra = {'QUERY_STRING':'a:long='}
+        extra = {'QUERY_STRING': 'a:long='}
         request = self._createRequest(extra)
         self.assertRaises(ValueError, publish, request)
 
-        extra = {'QUERY_STRING':'a:long=abc'}
+        extra = {'QUERY_STRING': 'a:long=abc'}
         request = self._createRequest(extra)
         self.assertRaises(ValueError, publish, request)
 
     def testFormTokensTypes(self):
-        extra = {'QUERY_STRING':'a:tokens=a%20b%20c%20d&b:tokens='}
+        extra = {'QUERY_STRING': 'a:tokens=a%20b%20c%20d&b:tokens='}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): [_u("a"), _u("b"), _u("c"), _u("d")],
-                         _u("b"): []})
+        self.assertEqual(request.form, {u"a": [u"a", u"b", u"c", u"d"],
+                         u"b": []})
 
     def testFormStringTypes(self):
-        extra = {'QUERY_STRING':'a:string=test&b:string='}
+        extra = {'QUERY_STRING': 'a:string=test&b:string='}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): _u("test"), _u("b"): _u("")})
+        self.assertEqual(request.form, {u"a": u"test", u"b": u""})
 
     def testFormLinesTypes(self):
-        extra = {'QUERY_STRING':'a:lines=a%0ab%0ac%0ad&b:lines='}
+        extra = {'QUERY_STRING': 'a:lines=a%0ab%0ac%0ad&b:lines='}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): [_u("a"), _u("b"), _u("c"), _u("d")],
-                         _u("b"): []})
+        self.assertEqual(request.form, {u"a": [u"a", u"b", u"c", u"d"],
+                         u"b": []})
 
     def testFormTextTypes(self):
-        extra = {'QUERY_STRING':'a:text=a%0a%0db%0d%0ac%0dd%0ae&b:text='}
+        extra = {'QUERY_STRING': 'a:text=a%0a%0db%0d%0ac%0dd%0ae&b:text='}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): _u("a\nb\nc\nd\ne"), _u("b"): _u("")})
+        self.assertEqual(request.form, {u"a": u"a\nb\nc\nd\ne", u"b": u""})
 
     def testFormRequiredTypes(self):
-        extra = {'QUERY_STRING':'a:required=%20'}
+        extra = {'QUERY_STRING': 'a:required=%20'}
         request = self._createRequest(extra)
         self.assertRaises(ValueError, publish, request)
 
     def testFormBooleanTypes(self):
-        extra = {'QUERY_STRING':'a:boolean=&b:boolean=1&c:boolean=%20'}
+        extra = {'QUERY_STRING': 'a:boolean=&b:boolean=1&c:boolean=%20'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"): False, _u("b"): True, _u("c"): True})
+        self.assertEqual(request.form, {u"a": False, u"b": True, u"c": True})
 
     def testFormDefaults(self):
-        extra = {'QUERY_STRING':'a:default=10&a=6&b=1'}
+        extra = {'QUERY_STRING': 'a:default=10&a=6&b=1'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"):_u("6"), _u("b"):_u("1")})
+        self.assertEqual(request.form, {u"a": u"6", u"b": u"1"})
 
     def testFormDefaults2(self):
-        extra = {'QUERY_STRING':'a:default=10&b=1'}
+        extra = {'QUERY_STRING': 'a:default=10&b=1'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"):_u("10"), _u("b"):_u("1")})
+        self.assertEqual(request.form, {u"a": u"10", u"b": u"1"})
 
     def testFormFieldName(self):
-        extra = {'QUERY_STRING':'c+%2B%2F%3D%26c%3Aint=6',
+        extra = {'QUERY_STRING': 'c+%2B%2F%3D%26c%3Aint=6',
                  'PATH_INFO': '/folder/item3/'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("c +/=&c"): 6})
+        self.assertEqual(request.form, {u"c +/=&c": 6})
 
     def testFormFieldValue(self):
-        extra = {'QUERY_STRING':'a=b+%2B%2F%3D%26b%3Aint',
+        extra = {'QUERY_STRING': 'a=b+%2B%2F%3D%26b%3Aint',
                  'PATH_INFO': '/folder/item3/'}
         request = self._createRequest(extra)
         publish(request)
-        self.assertEqual(request.form, {_u("a"):_u("b +/=&b:int")})
+        self.assertEqual(request.form, {u"a": u"b +/=&b:int"})
 
     def testInterface(self):
         request = self._createRequest()
@@ -525,12 +525,12 @@ class BrowserTests(HTTPTests):
 
     def testIssue559(self):
         extra = {'QUERY_STRING': 'HTTP_REFERER=peter',
-                 'HTTP_REFERER':'http://localhost/',
+                 'HTTP_REFERER': 'http://localhost/',
                  'PATH_INFO': '/folder/item3/'}
         request = self._createRequest(extra)
         publish(request)
         self.assertEqual(request.headers.get('HTTP_REFERER'), 'http://localhost/')
-        self.assertEqual(request.form, {_u("HTTP_REFERER"): _u("peter")})
+        self.assertEqual(request.form, {u"HTTP_REFERER": u"peter"})
 
 
     def test_post_body_not_consumed_unnecessarily(self):

--- a/src/zope/publisher/tests/test_browserresponse.py
+++ b/src/zope/publisher/tests/test_browserresponse.py
@@ -22,7 +22,6 @@ from zope.interface.verify import verifyObject
 from zope.publisher.interfaces.http import IHTTPResponse
 from zope.publisher.interfaces.http import IHTTPApplicationResponse
 from zope.publisher.interfaces import IResponse
-from .._compat import _u
 
 
 # TODO: Waaa need more tests
@@ -112,7 +111,7 @@ class TestBrowserResponse(TestCase):
             insertBase(b'<html><head></head><body>Page</body></html>'))
 
         # Ensure that unicode bases work as well
-        response.setBase(_u('http://localhost/folder/'))
+        response.setBase(u'http://localhost/folder/')
         body = insertBase(b'<html><head></head><body>Page</body></html>')
         self.assertTrue(isinstance(body, bytes))
         self.assertTrue(b'<base href="http://localhost/folder/" />' in body)

--- a/src/zope/publisher/tests/test_http.py
+++ b/src/zope/publisher/tests/test_http.py
@@ -38,7 +38,6 @@ from zope.publisher.interfaces.http import IHTTPRequest, IHTTPResponse
 from zope.publisher.interfaces.http import IHTTPApplicationResponse
 from zope.publisher.interfaces import IResponse
 from zope.publisher.tests.publication import TestPublication
-from .._compat import _u
 
 from zope.publisher.tests.basetestipublicationrequest \
      import BaseTestIPublicationRequest
@@ -463,14 +462,14 @@ class HTTPTests(unittest.TestCase):
         }
         req = self._createRequest(extra_env=cookies)
 
-        self.assertEqual(req.cookies[_u('foo')], _u('bar'))
-        self.assertEqual(req[_u('foo')], _u('bar'))
+        self.assertEqual(req.cookies[u'foo'], u'bar')
+        self.assertEqual(req[u'foo'], u'bar')
 
-        self.assertEqual(req.cookies[_u('spam')], _u('eggs'))
-        self.assertEqual(req[_u('spam')], _u('eggs'))
+        self.assertEqual(req.cookies[u'spam'], u'eggs')
+        self.assertEqual(req[u'spam'], u'eggs')
 
-        self.assertEqual(req.cookies[_u('this')], _u('Should be accepted'))
-        self.assertEqual(req[_u('this')], _u('Should be accepted'))
+        self.assertEqual(req.cookies[u'this'], u'Should be accepted')
+        self.assertEqual(req[u'this'], u'Should be accepted')
 
         # Reserved key
         self.assertFalse(req.cookies.has_key('path'))
@@ -509,7 +508,7 @@ class HTTPTests(unittest.TestCase):
         # Cookie values are assumed to be UTF-8 encoded
         cookies = {'HTTP_COOKIE': r'key="\342\230\243";'}
         req = self._createRequest(extra_env=cookies)
-        self.assertEqual(req.cookies[_u('key')], _u('\N{BIOHAZARD SIGN}'))
+        self.assertEqual(req.cookies[u'key'], u'\N{BIOHAZARD SIGN}')
 
     def testHeaders(self):
         headers = {
@@ -517,10 +516,10 @@ class HTTPTests(unittest.TestCase):
             'Another-Test': 'another',
         }
         req = self._createRequest(extra_env=headers)
-        self.assertEqual(req.headers[_u('TEST_HEADER')], _u('test'))
-        self.assertEqual(req.headers[_u('TEST-HEADER')], _u('test'))
-        self.assertEqual(req.headers[_u('test_header')], _u('test'))
-        self.assertEqual(req.getHeader('TEST_HEADER', literal=True), _u('test'))
+        self.assertEqual(req.headers[u'TEST_HEADER'], u'test')
+        self.assertEqual(req.headers[u'TEST-HEADER'], u'test')
+        self.assertEqual(req.headers[u'test_header'], u'test')
+        self.assertEqual(req.getHeader('TEST_HEADER', literal=True), u'test')
         self.assertEqual(req.getHeader('TEST-HEADER', literal=True), None)
         self.assertEqual(req.getHeader('test_header', literal=True), None)
         self.assertEqual(req.getHeader('Another-Test', literal=True),
@@ -682,10 +681,10 @@ class HTTPTests(unittest.TestCase):
         req = self._createRequest(
             {'PATH_INFO': '/\xc3\xa4\xc3\xb6/\xc3\xbc\xc3\x9f/foo/bar.html'})
         self.assertEqual(req._traversal_stack,
-            [_u('bar.html'), _u('foo'), _u('\u00fc\u00df'), _u('\u00e4\u00f6')])
+            [u'bar.html', u'foo', u'\u00fc\u00df', u'\u00e4\u00f6'])
         # the request should have converted PATH_INFO to unicode
         self.assertEqual(req['PATH_INFO'],
-            _u('/\u00e4\u00f6/\u00fc\u00df/foo/bar.html'))
+            u'/\u00e4\u00f6/\u00fc\u00df/foo/bar.html')
 
     def testResponseWriteFaile(self):
         self.assertRaises(TypeError,
@@ -700,7 +699,7 @@ class HTTPTests(unittest.TestCase):
     def test_unacceptable_charset(self):
         # Regression test for https://bugs.launchpad.net/zope3/+bug/98337
         request = self._createRequest({'HTTP_ACCEPT_CHARSET': 'ISO-8859-1'})
-        result = _u("Latin a with ogonek\u0105 Cyrillic ya \u044f")
+        result = u"Latin a with ogonek\u0105 Cyrillic ya \u044f"
         provideAdapter(HTTPCharsets)
         request.response.setHeader('Content-Type', 'text/plain')
 
@@ -761,7 +760,7 @@ class ConcreteHTTPTests(HTTPTests):
         # set the response on a result
         request = self._createRequest()
         request.response.setHeader('Content-Type', 'text/plain')
-        result = _u("Latin a with ogonek\u0105 Cyrillic ya \u044f")
+        result = u"Latin a with ogonek\u0105 Cyrillic ya \u044f"
         request.response.setResult(result)
 
         body = request.response.consumeBody()
@@ -827,7 +826,7 @@ class TestHTTPResponse(unittest.TestCase):
         eq(b"test", body)
 
         headers, body = self._getResultFromResponse(
-            _u('\u0442\u0435\u0441\u0442'), "utf-8",
+            u'\u0442\u0435\u0441\u0442', "utf-8",
             {"content-type": "text/plain"})
         eq("8", headers["Content-Length"])
         eq(b'\xd1\x82\xd0\xb5\xd1\x81\xd1\x82', body)
@@ -839,17 +838,17 @@ class TestHTTPResponse(unittest.TestCase):
         eq("", headers.get("Content-Type", ""))
         eq(b"test", body)
 
-        headers, body = self._getResultFromResponse(_u("test"),
+        headers, body = self._getResultFromResponse(u"test",
             headers={"content-type": "text/plain"})
         eq("text/plain;charset=utf-8", headers["Content-Type"])
         eq(b"test", body)
 
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "text/html"})
         eq("text/html;charset=utf-8", headers["Content-Type"])
         eq(b"test", body)
 
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "text/plain;charset=cp1251"})
         eq("text/plain;charset=cp1251", headers["Content-Type"])
         eq(b"test", body)
@@ -857,30 +856,30 @@ class TestHTTPResponse(unittest.TestCase):
         # see https://bugs.launchpad.net/zope.publisher/+bug/98395
         # RFC 3023 types and */*+xml output as unicode
 
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "text/xml"})
         eq("text/xml;charset=utf-8", headers["Content-Type"])
         eq(b"test", body)
 
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "application/xml"})
         eq("application/xml;charset=utf-8", headers["Content-Type"])
         eq(b"test", body)
 
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "text/xml-external-parsed-entity"})
         eq("text/xml-external-parsed-entity;charset=utf-8",
            headers["Content-Type"])
         eq(b"test", body)
 
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "application/xml-external-parsed-entity"})
         eq("application/xml-external-parsed-entity;charset=utf-8",
            headers["Content-Type"])
         eq(b"test", body)
 
         # Mozilla XUL
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "application/vnd+xml"})
         eq("application/vnd+xml;charset=utf-8", headers["Content-Type"])
         eq(b"test", body)
@@ -892,7 +891,7 @@ class TestHTTPResponse(unittest.TestCase):
         eq("image/gif", headers["Content-Type"])
         eq(b"test", body)
 
-        headers, body = self._getResultFromResponse(_u("test"), "utf-8",
+        headers, body = self._getResultFromResponse(u"test", "utf-8",
             {"content-type": "application/json"})
         eq("application/json", headers["Content-Type"])
         eq(b"test", body)
@@ -923,7 +922,7 @@ class TestHTTPResponse(unittest.TestCase):
         self.assertTrue('alpha=beta;' in c or 'alpha=beta' in c)
 
         c = self._getCookieFromResponse([
-                ('sign', _u('\N{BIOHAZARD SIGN}'), {}),
+                ('sign', u'\N{BIOHAZARD SIGN}', {}),
                 ])
         self.assertTrue((r'sign="\342\230\243";' in c) or
                         (r'sign="\342\230\243"' in c))
@@ -940,7 +939,7 @@ class TestHTTPResponse(unittest.TestCase):
                     'domain': 'example.com',
                     'pAth': '/froboz',
                     'max_age': 3600,
-                    'comment': _u('blah;\N{BIOHAZARD SIGN}?'),
+                    'comment': u'blah;\N{BIOHAZARD SIGN}?',
                     'seCure': True,
                     }),
                 ])[0]

--- a/src/zope/publisher/tests/test_paste.py
+++ b/src/zope/publisher/tests/test_paste.py
@@ -14,8 +14,6 @@
 import unittest
 import doctest
 
-from .._compat import _u
-
 
 class SamplePublication(object):
 
@@ -38,13 +36,12 @@ class SamplePublication(object):
         pass
 
     def callObject(self, request, ob):
-        return (_u('<html><body>Thanks for your request:<br />\n'
-                   '<h1>%s</h1>\n<pre>\n%s\n</pre>\n'
-                   '<h1>Publication arguments:</h1>\n'
-                   'Globals: %r<br />\nOptions: %r\n</body></html>')
-                % (request.__class__.__name__, request,
-                   self.args[0], self.args[1])
-                )
+        return (
+            u'<html><body>Thanks for your request:<br />\n'
+            u'<h1>%s</h1>\n<pre>\n%s\n</pre>\n'
+            u'<h1>Publication arguments:</h1>\n'
+            u'Globals: %r<br />\nOptions: %r\n</body></html>'
+        ) % (request.__class__.__name__, request, self.args[0], self.args[1])
 
     def afterCall(self, request, ob):
         pass

--- a/src/zope/publisher/tests/test_principallogging.py
+++ b/src/zope/publisher/tests/test_principallogging.py
@@ -15,11 +15,11 @@
 """
 import unittest
 from zope.interface.verify import verifyObject
-from .._compat import _u
+
 
 class PrincipalStub(object):
 
-    id = _u('\xfc principal')
+    id = u'\xfc principal'
 
 
 class TestPrincipalLogging(unittest.TestCase):

--- a/src/zope/publisher/zcml.py
+++ b/src/zope/publisher/zcml.py
@@ -22,7 +22,6 @@ from zope.publisher.interfaces import IDefaultViewName
 from zope.publisher.interfaces.browser import IBrowserRequest
 from zope.publisher.interfaces.browser import IBrowserSkinType
 from zope.publisher.interfaces.browser import IDefaultSkin
-from ._compat import _u
 from zope.schema import TextLine
 
 
@@ -30,8 +29,8 @@ class IDefaultSkinDirective(Interface):
     """Sets the default browser skin"""
 
     name = TextLine(
-        title=_u("Default skin name"),
-        description=_u("Default skin name"),
+        title=u"Default skin name",
+        description=u"Default skin name",
         required=True
         )
 
@@ -46,28 +45,28 @@ class IDefaultViewDirective(Interface):
     """
 
     name = TextLine(
-        title=_u("The name of the view that should be the default."),
-        description=_u("""
+        title=u"The name of the view that should be the default.",
+        description=u"""
         This name refers to view that should be the view used by
-        default (if no view name is supplied explicitly)."""),
+        default (if no view name is supplied explicitly).""",
         required=True
         )
 
     for_ = GlobalObject(
-        title=_u("The interface this view is the default for."),
-        description=_u("""
+        title=u"The interface this view is the default for.",
+        description=u"""
         Specifies the interface for which the view is registered.
 
         All objects implementing this interface can make use of
         this view. If this attribute is not specified, the view is available
-        for all objects."""),
+        for all objects.""",
         required=False
         )
 
     layer = GlobalInterface(
-        title=_u("The layer the default view is declared for"),
-        description=_u("The default layer for which the default view is "
-                       "applicable. By default it is applied to all layers."),
+        title=u"The layer the default view is declared for",
+        description=u"The default layer for which the default view is "
+                    u"applicable. By default it is applied to all layers.",
         required=False
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
 deps =
     {[testenv]deps}
     coverage
+parallel_show_output = true
 
 
 [testenv:docs]


### PR DESCRIPTION
The `_u()` compat function was necessary to support Python 3.0 and 3.1 which did not allow u-literals.  Today it only makes the code harder to read and understand.