### PR TITLE
Get rid of _u()

### DIFF
--- a/src/zope/publisher/_compat.py
+++ b/src/zope/publisher/_compat.py
@@ -23,15 +23,13 @@ PYTHON2 = sys.version_info[0] == 2
 PYTHON3 = sys.version_info[0] == 3
 
 if PYTHON2:
-    def _u(s, encoding='unicode_escape'):
-        return unicode(s, encoding)
+    def to_unicode(s):
+        return unicode(s, 'unicode_escape')
     from xmlrpclib import *
     import types
     CLASS_TYPES = (type, types.ClassType)
 else:
-    def _u(s, encoding=None):
-        if encoding is None:
-            return s
-        return str(s, encoding)
+    def to_unicode(s):
+        return s
     CLASS_TYPES = (type,)
     from xmlrpc.client import *

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -51,7 +51,7 @@ from zope.publisher.skinnable import setDefaultSkin #BBB import
 from zope.publisher.skinnable import applySkin #BBB import
 from zope.publisher.skinnable import SkinChangedEvent #BBB import
 
-from zope.publisher._compat import PYTHON2, _u
+from zope.publisher._compat import PYTHON2
 
 
 __ArrayTypes = (list, tuple)
@@ -259,7 +259,7 @@ class BrowserRequest(HTTPRequest):
             self.charsets = [c for c in self.charsets if c != '*']
         for charset in self.charsets:
             try:
-                text = _u(text, charset)
+                text = text.decode(charset)
                 break
             except UnicodeError:
                 pass
@@ -651,7 +651,7 @@ class FileUpload(object):
         self.headers = aFieldStorage.headers
         filename = aFieldStorage.filename
         if isinstance(aFieldStorage.filename, bytes):
-            filename = _u(aFieldStorage.filename, 'UTF-8')
+            filename = aFieldStorage.filename.decode('UTF-8')
         # fix for IE full paths
         filename = filename[filename.rfind('\\')+1:].strip()
         self.filename = filename

--- a/src/zope/publisher/http.py
+++ b/src/zope/publisher/http.py
@@ -41,7 +41,7 @@ import zope.contenttype.parse
 import zope.event
 import zope.interface
 
-from zope.publisher._compat import PYTHON2, CLASS_TYPES, _u
+from zope.publisher._compat import PYTHON2, CLASS_TYPES, to_unicode
 
 if PYTHON2:
     import Cookie as cookies
@@ -421,12 +421,15 @@ class HTTPRequest(BaseRequest):
             eventlog.warning(e)
             return result
 
-        for k,v in c.items():
+        for k, v in c.items():
             # recode cookie value to ENCODING (UTF-8)
-            rk = _u(k if type(k) == bytes
-                    else k.encode('latin1'), ENCODING)
-            rv = _u(v.value if type(v.value) == bytes
-                    else v.value.encode('latin1'), ENCODING)
+            if not isinstance(k, bytes):
+                k = k.encode('latin1')
+            rk = k.decode(ENCODING)
+            v = v.value
+            if not isinstance(v, bytes):
+                v = v.encode('latin1')
+            rv = v.decode(ENCODING)
             result[rk] = rv
 
         return result
@@ -865,7 +868,7 @@ class HTTPResponse(BaseResponse):
                 return
             title = tname = t.__name__
         else:
-            title = tname = _u(t)
+            title = tname = to_unicode(t)
 
         # Throwing non-protocol-specific exceptions is a good way
         # for apps to control the status code.


### PR DESCRIPTION
Where we know we have bytes, we can call bytes.decode() directly.

The one place where we don't know what we have, we'll have to keep calling unicode().  (That place is handling string exceptions AFAICT, which are not allowed on Python 3.)