### PR TITLE
Avoid using urllib.parse.splitport()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 5.1.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Avoid using ``urllib.parse.splitport()`` which was deprecated in Python 3.8.
+  See `issue 38 <https://github.com/zopefoundation/zope.publisher/issue/38>`_
 
 
 5.1.0 (2019-07-12)

--- a/src/zope/publisher/http.py
+++ b/src/zope/publisher/http.py
@@ -45,12 +45,12 @@ from zope.publisher._compat import PYTHON2, CLASS_TYPES, to_unicode
 
 if PYTHON2:
     import Cookie as cookies
-    from urllib import splitport, quote
+    from urllib import quote
     from urlparse import urlsplit
     from cgi import escape
 else:
     import http.cookies as cookies
-    from urllib.parse import splitport, quote, urlsplit
+    from urllib.parse import quote, urlsplit
     from html import escape
     unicode = str
     basestring = (str, bytes)
@@ -70,6 +70,37 @@ class CookieMapper(RequestDataMapper):
 
 class HeaderGetter(RequestDataGetter):
     _gettrname = 'getHeader'
+
+
+host_port_re = re.compile(
+    r"^(.*):([0-9]*)$", re.DOTALL)
+
+def splitport(host):
+    """Split port number off the hostname.
+
+        >>> splitport('example.com:80')
+        ('example.com', '80')
+
+        >>> splitport('localhost')
+        ('localhost', None)
+
+        >>> splitport('[::1]')
+        ('[::1]', None)
+
+        >>> splitport('[::1]:443')
+        ('[::1]', '443')
+
+        >>> splitport('localhost:')
+        ('localhost', None)
+
+    """
+    match = host_port_re.match(host)
+    if match:
+        host, port = match.groups()
+    else:
+        port = None
+    return host, port or None
+
 
 def sane_environment(env):
     # return an environment mapping which has been cleaned of

--- a/src/zope/publisher/tests/test_http.py
+++ b/src/zope/publisher/tests/test_http.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 import unittest
 from io import BytesIO
-from doctest import DocFileSuite
+from doctest import DocFileSuite, DocTestSuite
 
 import zope.event
 from zope.component import provideAdapter
@@ -1041,6 +1041,7 @@ def test_suite():
         unittest.makeSuite(ConcreteHTTPTests),
         unittest.makeSuite(TestHTTPResponse),
         unittest.makeSuite(HTTPInputStreamTests),
+        DocTestSuite('zope.publisher.http'),
         DocFileSuite('../httpresults.txt',
             setUp=cleanUp,
             tearDown=cleanUp,


### PR DESCRIPTION
The function is an undocumented internal helper and emits a deprecation warning in Python 3.8.

The suggested replacement is urllib.parse.urlparse(), but it's awkward for our use case (you have to add a scheme so it doesn't treat the argument as a relative URL, and it unwraps IPv6 addresses that we'd have to wrap right back into [], and it converts the port to an int whereas we expect it to be a string) so let's just reimplement the function using a regexp (which is what the stdlib did anyway).

Fixes #38.