### PR TITLE
Fix inconsistent resolution orders and add Python 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
-dist: xenial
 python:
     - 2.7
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
     - pypy
     - pypy3
+env:
+  global:
+    - ZOPE_INTERFACE_STRICT_IRO: 1
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,16 @@
  Changes
 =========
 
-5.1.2 (unreleased)
+5.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for Python 3.8.
 
+- Ensure all objects have a consistent interface resolution order. See
+  `issue 49
+  <https://github.com/zopefoundation/zope.publisher/issues/49>`_.
+
+- Drop support for the deprecated ``python setup.py test`` command.
 
 5.1.1 (2019-08-08)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -20,21 +20,6 @@ import os
 from setuptools import setup, find_packages
 
 
-def alltests():
-    import sys
-    import unittest
-    # use the zope.testrunner machinery to find all the
-    # test suites we've put under ourselves
-    import zope.testrunner.find
-    import zope.testrunner.options
-    here = os.path.abspath(os.path.join(os.path.dirname(__file__), 'src'))
-    args = sys.argv[:]
-    defaults = ["--test-path", here]
-    options = zope.testrunner.options.get_options(args, defaults)
-    suites = list(zope.testrunner.find.find_suites(options))
-    return unittest.TestSuite(suites)
-
-
 def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
@@ -54,7 +39,7 @@ tests_require = [
 
 setup(
     name='zope.publisher',
-    version='5.1.2.dev0',
+    version='5.2.0.dev0',
     url='https://github.com/zopefoundation/zope.publisher',
     license='ZPL 2.1',
     author='Zope Foundation and Contributors',
@@ -72,6 +57,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',
@@ -105,7 +91,6 @@ setup(
         ],
     },
     tests_require=tests_require,
-    test_suite='__main__.alltests',
     entry_points=entry_points,
     include_package_data=True,
     zip_safe=False,

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -889,7 +889,7 @@ class NotCompatibleAdapterError(Exception):
 
 BROWSER_LANGUAGES_KEY = "zope.publisher.browser.IUserPreferredLanguages"
 
-@implementer(IUserPreferredLanguages)
+
 class CacheableBrowserLanguages(BrowserLanguages):
 
     def getPreferredLanguages(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,40 +1,40 @@
 [tox]
 envlist =
-    py27,py35,py36,py37,pypy,pypy3,docs,coverage
+    py27,py35,py36,py37,py38,pypy,pypy3,coverage,docs
+# Note: if you add new Python versions, please add them to
+# [testenv:coverage] depends as well!
 
 [testenv]
 commands =
-    zope-testrunner --test-path=src {posargs:-vc}
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
+    coverage run -p -m zope.testrunner --test-path=src []
+extras =
+    test
 deps =
-    .[test]
-
-[testenv:pypy3]
+    coverage
+setenv =
+     ZOPE_INTERFACE_STRICT_IRO=1
 # On certain platforms, at least OS X, pypy3 does not correctly read
 # a LANG environment variable; when cpython3.2 would return 'utf-8'
 # from locale.getpreferredencoding(), pypy3 returns 'us-ascii', causing
 # two test failures. Fix that by setting something it does read.
-setenv =
-    LC_CTYPE=en_US.UTF-8
+     pypy3: LC_CTYPE=en_US.UTF-8
 
 [testenv:coverage]
-usedevelop = true
-basepython =
-    python3.6
+skip_install = true
 commands =
-    coverage run -m zope.testrunner --test-path=src {posargs:-vc}
-    coverage report --fail-under=92
-deps =
-    {[testenv]deps}
-    coverage
+    coverage erase
+    coverage combine
+    coverage html -i
+    coverage report --fail-under=93 --show-missing
+# parallel mode: make sure all builds complete before we run this one
+depends =
+    py27,py35,py36,py37,py38,pypy,pypy3
 parallel_show_output = true
-
 
 [testenv:docs]
 basepython =
-    python3.6
+    python3
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-deps =
-    {[testenv]deps}
-    .[docs]
+extras =
+    docs


### PR DESCRIPTION
There was one class that re-declared what its direct superclass, implemented immediately above it, already declared.

Fixes #49

(tox.ini essentially copied from zope.traversing.)