### PR TITLE
Fix isHTML check under Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix text/bytes handling on Python 3 for some response edge cases.
 
 
 5.2.0 (2020-03-30)

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -25,6 +25,7 @@ import re
 import tempfile
 from cgi import FieldStorage
 
+import six
 import zope.component
 import zope.interface
 from zope.interface import implementer, directlyProvides
@@ -813,6 +814,8 @@ class BrowserResponse(HTTPResponse):
 
 def isHTML(str):
      """Try to determine whether str is HTML or not."""
+     if isinstance(str, six.binary_type):
+         str = str.decode()
      s = str.lstrip().lower()
      if s.startswith('<!doctype html'):
          return True

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -815,7 +815,10 @@ class BrowserResponse(HTTPResponse):
 def isHTML(str):
      """Try to determine whether str is HTML or not."""
      if isinstance(str, six.binary_type):
-         str = str.decode()
+         try:
+             str = str.decode()
+         except UnicodeDecodeError:
+             return False
      s = str.lstrip().lower()
      if s.startswith('<!doctype html'):
          return True

--- a/src/zope/publisher/http.py
+++ b/src/zope/publisher/http.py
@@ -821,6 +821,8 @@ class HTTPResponse(BaseResponse):
                 if isinstance(result, basestring):
                     r = result
                 elif result is None:
+                    # Default to bytes because unicode results require a
+                    # corresponding Content-Type header.
                     r = b''
                 else:
                     raise TypeError(
@@ -848,7 +850,7 @@ class HTTPResponse(BaseResponse):
 
     def _implicitResult(self, body):
         encoding = getCharsetUsingRequest(self._request) or 'utf-8'
-        content_type = self.getHeader('content-type')
+        content_type = self.getHeader('content-type') or ''
 
         if isinstance(body, unicode):
             ct = content_type

--- a/src/zope/publisher/http.py
+++ b/src/zope/publisher/http.py
@@ -821,7 +821,7 @@ class HTTPResponse(BaseResponse):
                 if isinstance(result, basestring):
                     r = result
                 elif result is None:
-                    r = ''
+                    r = b''
                 else:
                     raise TypeError(
                         'The result should be None, a string, or adaptable to '

--- a/src/zope/publisher/tests/test_browserresponse.py
+++ b/src/zope/publisher/tests/test_browserresponse.py
@@ -93,6 +93,14 @@ class TestBrowserResponse(TestCase):
             response.getHeader('content-type').startswith("text/plain")
             )
 
+        response = BrowserResponse()
+        response.setResult(
+            b"""\xff
+            """)
+        self.assertTrue(
+            response.getHeader('content-type').startswith("text/plain")
+            )
+
     def test_not_DWIM_for_304_response(self):
         # Don't guess the content type with 304 responses which MUST NOT /
         # SHOULD NOT include it.

--- a/src/zope/publisher/tests/test_browserresponse.py
+++ b/src/zope/publisher/tests/test_browserresponse.py
@@ -85,6 +85,14 @@ class TestBrowserResponse(TestCase):
             response.getHeader('content-type').startswith("text/plain")
             )
 
+        response = BrowserResponse()
+        response.setResult(
+            b"""Hello world
+            """)
+        self.assertTrue(
+            response.getHeader('content-type').startswith("text/plain")
+            )
+
     def test_not_DWIM_for_304_response(self):
         # Don't guess the content type with 304 responses which MUST NOT /
         # SHOULD NOT include it.

--- a/src/zope/publisher/tests/test_http.py
+++ b/src/zope/publisher/tests/test_http.py
@@ -896,6 +896,13 @@ class TestHTTPResponse(unittest.TestCase):
         eq("application/json", headers["Content-Type"])
         eq(b"test", body)
 
+        # zope.app.exception.browser.unauthorized in combination with
+        # zope.pluggableauth.plugins.session.SessionCredentialsPlugin (which
+        # redirects to login form on 401/403) produces a None body
+        response = HTTPResponse()
+        response.setResult(None)
+        eq(b"", response.consumeBody())
+
     def _getCookieFromResponse(self, cookies):
         # Shove the cookies through request, parse the Set-Cookie header
         # and spit out a list of headers for examination

--- a/src/zope/publisher/tests/test_http.py
+++ b/src/zope/publisher/tests/test_http.py
@@ -903,6 +903,18 @@ class TestHTTPResponse(unittest.TestCase):
         response.setResult(None)
         eq(b"", response.consumeBody())
 
+        response = HTTPResponse()
+        response.setResult(b'')
+        eq(b"", response.consumeBody())
+
+        response = HTTPResponse()
+        self.assertRaises(ValueError, response.setResult, u'')
+
+        response = HTTPResponse()
+        response.setHeader('Content-Type', 'text/plain')
+        response.setResult(u'')
+        eq(b"", response.consumeBody())
+
     def _getCookieFromResponse(self, cookies):
         # Shove the cookies through request, parse the Set-Cookie header
         # and spit out a list of headers for examination


### PR DESCRIPTION
setResult accepts "basestring" (which is defined as `(str, bytes)`), so isHTML must be able to handle bytes as well.