### PR TITLE
Introduce IJSONRequest interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Provide new interface ``IJSONRequest`` used to mark requests with an ``Accept: application/json`` header.
 
 
 5.2.0 (2020-03-30)

--- a/src/zope/publisher/interfaces/http.py
+++ b/src/zope/publisher/interfaces/http.py
@@ -213,6 +213,11 @@ class IHTTPRequest(IRequest):
         """
 
 
+class IJSONRequest(IHTTPRequest):
+    """Marker interface for JSON requests.
+    """
+
+
 class IHTTPView(IView):
     "HTTP View"
 


### PR DESCRIPTION
Provide new interface IJSONRequest used to mark requests with an Accept: application/json header.

Very early draft for exploring ideas on supporting application/json requests and possibly other type of requests.
Those requests can than explicitly be adapted to.

Related PRs:
https://github.com/zopefoundation/Zope/pull/845
https://github.com/zopefoundation/zope.publisher/pull/53

References the discussion plone.rest and how it intercepts the traversing chain for JSON requests: https://community.plone.org/t/json-application-messaging-in-plone-core/12353