### PR TITLE
Fix test compatibility with zope.interface 5.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix test compatibility with zope.interface 5.4.
 
 
 6.0.0 (2021-01-20)

--- a/src/zope/publisher/configure.txt
+++ b/src/zope/publisher/configure.txt
@@ -10,8 +10,19 @@ adapters and security:
 
   >>> XMLConfig('configure.zcml', zope.publisher)()
 
-  >>> len(list(zope.component.getGlobalSiteManager().registeredUtilities()))
-  22
+The exact count of registered utilities will vary depending on which
+packages are installed because of the use of
+``zcml:condition="installed ..."`` clauses in the ZCML.
+
+  >>> try:
+  ...    import zope.annotation
+  ... except ImportError:
+  ...   expected_count = 22
+  ... else:
+  ...   expected_count = 23
+
+  >>> len(list(zope.component.getGlobalSiteManager().registeredUtilities())) == expected_count
+  True
 
   >>> len(list(zope.component.getGlobalSiteManager().registeredAdapters()))
   11

--- a/src/zope/publisher/skinnable.py
+++ b/src/zope/publisher/skinnable.py
@@ -63,7 +63,7 @@ def setDefaultSkin(request):
             # silently ignore skins which do not provide ISkinType
             zope.interface.directlyProvides(request, skin)
         else:
-            raise TypeError("Skin interface %s doesn't provide ISkinType" %
+            raise TypeError("Skin interface %r doesn't provide ISkinType" %
                             skin)
 
 


### PR DESCRIPTION
Explicitly use the repr of interfaces so we can work with any version of zope.interface.

See https://github.com/zopefoundation/zope.interface/pull/237#issuecomment-807188771

(skinnable.py was using dos line endings so the diff had weird chars—^M— in it. I converted to standard line endings. Suggest viewing with whitespace changes off.)

There was a flaky test that didn't run in my environment because my virtual environment had zope.annotation installed. I tweaked it to work either way because I didn't want to add a new test dependency. I'm not sure how much value asserting the exact number of registered utilities/adapters adds though, so if there's a consensus about simplifying (e.g., before loading configure.zcml, there should be nothing registered, afterwards there should be at least something) I'm happy to try that instead. Or if the whole thing is too invasive I'll back it out..but it was confusing to find what the issue was.