### PR TITLE
Avoid traceback reference cycle in publish

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.0.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Avoid traceback reference cycle in ``zope.publisher.publish.publish``.
 
 
 6.0.1 (2021-04-15)

--- a/src/zope/publisher/publish.py
+++ b/src/zope/publisher/publish.py
@@ -164,6 +164,7 @@ def publish(request, handle_errors=True):
                                 if reraise is None or reraise():
                                     raise
                     finally:
+                        exc_info = None  # Avoid circular reference.
                         publication.endRequest(request, obj)
 
                     break  # Successful.


### PR DESCRIPTION
``sys.exc_info()`` called from ``publish`` returns a tuple containing the exception's traceback object, which has a reference to the
``publish`` frame.  Storing that in a local variable creates a reference cycle.  Clear that variable in a ``finally`` block to avoid this.

I don't have a test for this, nor much of an idea of how to write one.  I noticed it while auditing an application for reference cycle problems of this kind after finding that it had severe memory leaks on Python 3; this probably doesn't contribute much to that, but it seems worth fixing anyway.