### PR TITLE
Handle empty Content-Type environment variable gracefully

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 ==================
 
 - Avoid traceback reference cycle in ``zope.publisher.publish.publish``.
+- Handle empty Content-Type environment variable gracefully.
 
 
 6.0.1 (2021-04-15)

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -336,6 +336,12 @@ class BrowserRequest(HTTPRequest):
             # multipart doesn't actually care beyond an initial check, so
             # just pretend everything is POST from here on.
             env['REQUEST_METHOD'] = 'POST'
+
+            # According to PEP 333 CONTENT_LENGTH may be empty or absent.
+            # An empty string here breaks multipart, because it's an invalid
+            # value according to RFC 2616 (HTTP/1.1).
+            if env.get('CONTENT_LENGTH') == '':
+                env.pop('CONTENT_LENGTH')
             forms, files = multipart.parse_form_data(
                 env, charset='ISO-8859-1', memfile_limit=0)
             items.extend(forms.iterallitems())


### PR DESCRIPTION
Related to PR in multipart https://github.com/defnull/multipart/pull/35

The empty CONTENT_LENGTH header variable can be added by a webserver like nginx. Empty string is valid as WSGI env variable (PEP0333), not so much as HTTP env variable (RFC2616).