### PR TITLE
Fixes for multipart 1.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,15 @@
 7.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix test suite to use proper line endings (\r\n) in raw multipart/form-data
+  HTTP requests, because multipart 1.0.0 is stricter about line endings.
+  Fixes `issue <https://github.com/zopefoundation/zope.publisher/issues/74>`_.
+
+- ``FileUpload`` objects now implement a fallback ``seekable()`` method on
+  Python 3.7 through 3.10, where tempfile.SpooledTemporaryFile lacks it.
+  Fixes `issue 44 <https://github.com/zopefoundation/zope.publisher/issues/44>`_
+  again, which had regressed due to certain assumptions that were no longer
+  true after the multipart 1.0.0 release.
 
 
 7.0 (2023-08-29)

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -680,7 +680,7 @@ class FileUpload:
         if 'seekable' not in d and isinstance(
             file, tempfile.SpooledTemporaryFile
         ):
-            # NB: can't assing file._file.seekable, file._file might roll over
+            # NB: can't assign file._file.seekable, file._file might roll over
             d['seekable'] = lambda: file._file.seekable()
 
         self.headers = aFieldStorage.headers

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -19,6 +19,7 @@ HTML form data and convert them into a Python-native format. Even file data is
 packaged into a nice, Python-friendly 'FileUpload' object.
 """
 import re
+import tempfile
 from email.message import Message
 from urllib.parse import parse_qsl
 
@@ -675,6 +676,12 @@ class FileUpload:
         for m in methods:
             if hasattr(file, m):
                 d[m] = getattr(file, m)
+
+        if 'seekable' not in d and isinstance(
+            file, tempfile.SpooledTemporaryFile
+        ):
+            # NB: can't assing file._file.seekable, file._file might roll over
+            d['seekable'] = lambda: file._file.seekable()
 
         self.headers = aFieldStorage.headers
         filename = aFieldStorage.filename

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -679,7 +679,7 @@ class FileUpload:
 
         if 'seekable' not in d and isinstance(
             file, tempfile.SpooledTemporaryFile
-        ):
+        ):  # Python 3.7 to 3.10
             # NB: can't assign file._file.seekable, file._file might roll over
             d['seekable'] = lambda: file._file.seekable()
 

--- a/src/zope/publisher/tests/test_browserrequest.py
+++ b/src/zope/publisher/tests/test_browserrequest.py
@@ -43,7 +43,7 @@ Content-Disposition: form-data; name="upload"; filename=""
 Content-Type: application/octet-stream
 
 -----------------------------1--
-"""
+""".replace(b'\n', b'\r\n')
 
 LARGE_FILE_BODY = b''.join([b"""-----------------------------1
 Content-Disposition: form-data; name="upload"; filename="test"
@@ -51,14 +51,14 @@ Content-Type: text/plain
 
 Here comes some text! """, (b'test' * 1000), b"""
 -----------------------------1--
-"""])
+"""]).replace(b'\n', b'\r\n')
 
 LARGE_POSTED_VALUE = b''.join([b"""-----------------------------1
 Content-Disposition: form-data; name="upload"
 
 Here comes some text! """, (b'test' * 1000), b"""
 -----------------------------1--
-"""])
+"""]).replace(b'\n', b'\r\n')
 
 IE_FILE_BODY = b"""-----------------------------1
 Content-Disposition: form-data; name="upload"; filename="C:\\Windows\\notepad.exe"
@@ -66,7 +66,7 @@ Content-Type: text/plain
 
 Some data
 -----------------------------1--
-"""  # noqa: E501 line too long
+""".replace(b'\n', b'\r\n')  # noqa: E501 line too long
 
 
 def publish(request):
@@ -307,7 +307,7 @@ class BrowserTests(HTTPTests):
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form_data; boundary=-123',
         }
-        body = b'\n'.join([
+        body = b'\r\n'.join([
             b'---123',
             b'Content-Disposition: form-data; name="a"',
             b'',
@@ -333,7 +333,7 @@ class BrowserTests(HTTPTests):
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form_data; boundary=-123',
         }
-        body = b'\n'.join([
+        body = b'\r\n'.join([
             b'---123',
             b'Content-Disposition: form-data; name="upload";'
             b' filename="\xe2\x98\x83"',
@@ -355,7 +355,7 @@ class BrowserTests(HTTPTests):
             'CONTENT_TYPE': (
                 'multipart/form_data; boundary=-123; charset=ISO-8859-13'),
         }
-        body = b'\n'.join([
+        body = b'\r\n'.join([
             b'---123',
             b'Content-Disposition: form-data; name="upload";'
             b' filename="\xc0\xfeuolyno"',
@@ -376,7 +376,7 @@ class BrowserTests(HTTPTests):
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form_data; boundary=-123',
         }
-        body = b'\n'.join([
+        body = b'\r\n'.join([
             b'---123',
             b'Content-Disposition: form-data; name="upload";'
             b' filename="\xc0\xfeuolyno"',
@@ -681,7 +681,7 @@ class BrowserTests(HTTPTests):
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form_data; boundary=-123',
         }
-        body = b'\n'.join([
+        body = b'\r\n'.join([
             b'---123',
             b'Content-Disposition: form-data; name="a"',
             b'',


### PR DESCRIPTION
- The new multipart parser is strict about line endings, so be sure to use \r\n
- The new multipart parser uses tempfile.SpooledTemporaryFile objects, which do not have a seekable() method on Python before 3.11.

This fixes both issues and makes the tests pass.

Closes #74, #44.