### PR TITLE
Replace deprecated multipart argument memfile_limit with spool_limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 7.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace deprecated multipart argument ``memfile_limit`` with ``spool_limit``
 
 
 7.1 (2024-09-27)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     package_dir={'': 'src'},
     namespace_packages=['zope'],
     install_requires=[
-        'multipart',
+        'multipart>=1.1.0',
         'setuptools',
         'zope.browser',
         'zope.component',

--- a/src/zope/publisher/browser.py
+++ b/src/zope/publisher/browser.py
@@ -341,7 +341,7 @@ class BrowserRequest(HTTPRequest):
             if env.get('CONTENT_LENGTH') == '':
                 env.pop('CONTENT_LENGTH')
             forms, files = multipart.parse_form_data(
-                env, charset=self.default_form_charset, memfile_limit=0)
+                env, charset=self.default_form_charset, spool_limit=0)
             items.extend(forms.iterallitems())
             for key, item in files.iterallitems():
                 # multipart puts fields in 'files' even if no upload was


### PR DESCRIPTION
Hello everyone,

`memfile_limit` has been replaced by `spool_limit`, see https://github.com/defnull/multipart/blob/master/multipart.py#L576.

Unfortunately they use `self.spool_limit = memfile_limit or spool_limit`, so if `memfile_limit = 0` it will always be the default `spool_limit` instead.